### PR TITLE
Move provide form to the end of file

### DIFF
--- a/io-mode.el
+++ b/io-mode.el
@@ -378,9 +378,6 @@
   ;; hooks
   (set (make-local-variable 'before-save-hook) 'io-before-save))
 
-(provide 'io-mode)
-
-
 ;;
 ;; On Load
 ;;
@@ -388,3 +385,5 @@
 ;; Run io-mode for files ending in .io.
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.io$" . io-mode))
+
+(provide 'io-mode)


### PR DESCRIPTION
Any errors in the code after `provide` will leave the feature registered, so `provide` form should always be at the end.
