### PR TITLE
Add footer line for ELPA compatibility

### DIFF
--- a/io-mode.el
+++ b/io-mode.el
@@ -23,7 +23,7 @@
 ;; along with this program; if not, write to the Free Software
 ;; Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
-;;; Commentary
+;;; Commentary:
 
 ;; No documentation is availible at the moment, but a nice and clean
 ;; README is soon to come.
@@ -388,3 +388,5 @@
 ;; Run io-mode for files ending in .io.
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.io$" . io-mode))
+
+;;; io-mode.el ends here


### PR DESCRIPTION
This commit makes `io-mode.el` installable with package.el.
- add footer line
- fix Commentary section

For information about this fix, See following GNU Emacs Manual:
- [Library-Headers](http://www.gnu.org/software/emacs/manual/html_node/elisp/Library-Headers.html)
