### PR TITLE
Font lock improvements

### DIFF
--- a/io-mode.el
+++ b/io-mode.el
@@ -113,7 +113,7 @@
 ;;
 
 ;; Special? Self and call objects are :)
-(defvar io-special-re "\\<self\\|thisContext\\|call\\>")
+(defvar io-special-re (regexp-opt '("self" "thisContext" "call") 'symbols))
 
 ;; Operators (not all of them are present in the Io core,
 ;; but you can still define them, if you need it)
@@ -154,16 +154,24 @@
      "then" "thisBlock" "thisMessage" "try" "type"
      "uniqueId" "updateSlot" "wait" "while" "write"
      "writeln" "yield")
-   'words))
+   'symbols))
 
 ;; Comments
 (defvar io-comments-re "\\(\\(#\\|//\\).*$\\|/\\*\\(.\\|[\r\n]\\)*?\\*/\\)")
+
+;; Methods
+(defvar io-method-declaration-name-re "\\(\\sw+\\)\s*:=\s*\\(method\\)")
+
+;; Variables
+(defvar io-variable-declaration-name-re "\\(\\sw+\\)\s*:=\s*\\(\\sw+\\)")
 
 ;; Create the list for font-lock. Each class of keyword is given a
 ;; particular face.
 (defvar io-font-lock-keywords
   ;; Note: order here matters!
   `((,io-special-re . font-lock-variable-name-face)
+    (,io-method-declaration-name-re (1 font-lock-function-name-face))
+    (,io-variable-declaration-name-re (1 font-lock-variable-name-face))
     (,io-operators-re . font-lock-builtin-face)
     (,io-operators-special-re . font-lock-warning-face)
     (,io-boolean-re . font-lock-constant-face)


### PR DESCRIPTION
Now special symbols like `exit` and `clone` will not be highlighted when they occur inside other symbols. For instance, the word exit will not be highlighted in `my_exit_function`.

Also, function names will now be highlighted by the `font-lock-function-name-face` which before was unused. 

A symbol is considered a function name when it is followed by `:= method`

Variable declarations will also be highlighted with the `font-lock-variable-name-face`.

A symbol is considered a variable declaration when it is followed by `:= <something>`

before: 
![screen shot 2014-08-12 at 1 34 15 pm](https://cloud.githubusercontent.com/assets/1441728/3894698/11f3f290-2247-11e4-92a0-080a670c5178.png)

after:
![screen shot 2014-08-12 at 1 34 35 pm](https://cloud.githubusercontent.com/assets/1441728/3894701/17f03082-2247-11e4-80a3-ab1990cf42dc.png)
