### PR TITLE
Indentation changes

### DIFF
--- a/io-mode.el
+++ b/io-mode.el
@@ -6,6 +6,7 @@
 ;; Keywords: languages, io
 ;; Author: Sergei Lebedev <superbobry@gmail.com>
 ;; URL: https://github.com/superbobry/io-mode
+;; Package-Requires: ((cl-lib "0.3") (emacs "24.1"))
 
 ;; This file is not part of GNU Emacs.
 
@@ -56,6 +57,7 @@
 (require 'font-lock)
 (require 'hideshow)
 (require 'newcomment)
+(require 'cl-lib)
 
 ;;
 ;; Customizable Variables
@@ -295,7 +297,7 @@ is used to limit the scan."
   (save-excursion
     (back-to-indentation)
     (let* ((syntax (syntax-ppss (point)))
-           (desired-depth (- (length (cl-remove-duplicates (mapcar 'line-number-at-pos (tenth syntax))))
+           (desired-depth (- (length (cl-remove-duplicates (mapcar 'line-number-at-pos (cl-tenth syntax))))
                              (if (save-excursion (> (first syntax) (first (syntax-ppss (1+ (point)))))) 1 0))))
       (unless (or (io-in-string-p (line-beginning-position)) (eql (current-indentation) (* desired-depth tab-width)))
         (delete-region (point) (line-beginning-position))
@@ -359,7 +361,7 @@ is used to limit the scan."
 
   (set (make-local-variable 'electric-indent-chars)
        (string-to-list "(){}[]\n"))
-  (electric-indent-mode t)
+  (electric-indent-mode 1)
 
   ;; hideshow
   (unless (assq 'io-mode hs-special-modes-alist)

--- a/io-mode.el
+++ b/io-mode.el
@@ -89,7 +89,6 @@
 (defvar io-mode-map (make-keymap)
   "Keymap for Io major mode.")
 
-
 ;;
 ;; Macros
 ;;
@@ -177,6 +176,18 @@
 (defvar io-string-delimiter-re
   (rx (group (or  "\"" "\"\"\""))))
 
+(defun io-syntax-count-quotes (quote-char &optional point limit)
+  "Count number of quotes around point (max is 3).
+QUOTE-CHAR is the quote char to count.  Optional argument POINT is
+the point where scan starts (defaults to current point), and LIMIT
+is used to limit the scan."
+  (let ((i 0))
+    (while (and (< i 3)
+                (or (not limit) (< (+ point i) limit))
+                (eq (char-after (+ point i)) quote-char))
+      (incf i))
+    i))
+
 (defun io-syntax-stringify ()
   "Put `syntax-table' property correctly on single/triple quotes."
   (let* ((num-quotes (length (match-string-no-properties 1)))
@@ -189,7 +200,7 @@
          (quote-ending-pos (point))
          (num-closing-quotes
           (and string-start
-               (python-syntax-count-quotes
+               (io-syntax-count-quotes
                 (char-before) string-start quote-starting-pos))))
     (cond ((and string-start (= num-closing-quotes 0))
            nil)
@@ -270,7 +281,6 @@
   "Hook run before file is saved. Deletes whitespace if `io-cleanup-whitespace' is non-nil."
   (when io-cleanup-whitespace
     (delete-trailing-whitespace)))
-
 
 ;;
 ;; Indentation

--- a/io-mode.el
+++ b/io-mode.el
@@ -297,7 +297,7 @@ is used to limit the scan."
     (let* ((syntax (syntax-ppss (point)))
            (desired-depth (- (length (cl-remove-duplicates (mapcar 'line-number-at-pos (tenth syntax))))
                              (if (save-excursion (> (first syntax) (first (syntax-ppss (1+ (point)))))) 1 0))))
-      (unless (or (io-in-string-p (line-beginning-position)) (eql (current-indentation) (* desired tab-width)))
+      (unless (or (io-in-string-p (line-beginning-position)) (eql (current-indentation) (* desired-depth tab-width)))
         (delete-region (point) (line-beginning-position))
         (insert-tab desired-depth))))
   (when (> (save-excursion (back-to-indentation) (point)) (point))

--- a/io-mode.el
+++ b/io-mode.el
@@ -294,11 +294,12 @@ is used to limit the scan."
   "Indent current line as Io source."
   (save-excursion
     (back-to-indentation)
-    (let* ((syntax (syntax-ppss (point))))
-      (unless (io-in-string-p (line-beginning-position))
+    (let* ((syntax (syntax-ppss (point)))
+           (desired-depth (- (length (cl-remove-duplicates (mapcar 'line-number-at-pos (tenth syntax))))
+                             (if (save-excursion (> (first syntax) (first (syntax-ppss (1+ (point)))))) 1 0))))
+      (unless (or (io-in-string-p (line-beginning-position)) (eql (current-indentation) (* desired tab-width)))
         (delete-region (point) (line-beginning-position))
-        (insert-tab (- (length (cl-remove-duplicates (mapcar 'line-number-at-pos (tenth syntax))))
-                       (if (save-excursion (> (first syntax) (first (syntax-ppss (1+ (point)))))) 1 0))))))
+        (insert-tab desired-depth))))
   (when (> (save-excursion (back-to-indentation) (point)) (point))
     (back-to-indentation)))
 

--- a/io-mode.el
+++ b/io-mode.el
@@ -297,7 +297,7 @@ is used to limit the scan."
     (let* ((syntax (syntax-ppss (point))))
       (unless (io-in-string-p (line-beginning-position))
         (delete-region (point) (line-beginning-position))
-        (insert-tab (- (length (remove-duplicates (mapcar 'line-number-at-pos (tenth syntax))))
+        (insert-tab (- (length (cl-remove-duplicates (mapcar 'line-number-at-pos (tenth syntax))))
                        (if (save-excursion (> (first syntax) (first (syntax-ppss (1+ (point)))))) 1 0))))))
   (when (> (save-excursion (back-to-indentation) (point)) (point))
     (back-to-indentation)))


### PR DESCRIPTION
There are two changes here:

One is removing a python dependency that slipped into the last PR.

The big one is a rewrite of the indentation code. 

When indenting, there is now always a "right" place to indent the code to. This allow functions like `indent-region` to work. 

The `indent-and-newline` function was removed and replaced by specifying chars to use for electric indentation and activating electric indentation mode. 

The only downside is not allowing customization of the indent style. But I'm working on that. (Things like specifying that a line of code with only a comma should be indented one level less than normal)
