### PR TITLE
Fix package

### DIFF
--- a/io-mode.el
+++ b/io-mode.el
@@ -182,6 +182,14 @@
 (defvar io-string-delimiter-re
   (rx (group (or  "\"" "\"\"\""))))
 
+(defun io-syntax-count-quotes (quote-char point limit)
+  (let ((i 0))
+    (while (and (< i 3)
+                (or (not limit) (< (+ point i) limit))
+                (eq (char-after (+ point i)) quote-char))
+      (setq i (1+ i)))
+    i))
+
 (defun io-syntax-stringify ()
   "Put `syntax-table' property correctly on single/triple quotes."
   (let* ((num-quotes (length (match-string-no-properties 1)))
@@ -194,7 +202,7 @@
          (quote-ending-pos (point))
          (num-closing-quotes
           (and string-start
-               (python-syntax-count-quotes
+               (io-syntax-count-quotes
                 (char-before) string-start quote-starting-pos))))
     (cond ((and string-start (= num-closing-quotes 0))
            nil)

--- a/io-mode.el
+++ b/io-mode.el
@@ -179,8 +179,9 @@
     (,io-messages-re . font-lock-keyword-face)
     (,io-comments-re . font-lock-comment-face)))
 
-(defvar io-string-delimiter-re
-  (rx (group (or  "\"" "\"\"\""))))
+(eval-and-compile
+  (defvar io-string-delimiter-re
+    (rx (group (or  "\"" "\"\"\"")))))
 
 (defun io-syntax-count-quotes (quote-char point limit)
   (let ((i 0))


### PR DESCRIPTION
- Remove python-mode dependency(This is related to #11)
- Fix byte-compile error as below

```
io-mode.el:410:26:Error: Symbol’s value as variable is void: io-string-delimiter-re
```
